### PR TITLE
Update tar to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1666,6 +1666,12 @@
         "readdirp": "^2.0.0"
       }
     },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+      "dev": true
+    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -3609,6 +3615,15 @@
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
+    },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
     },
     "fs-readdir-recursive": {
       "version": "1.1.0",
@@ -5977,6 +5992,33 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
+    },
+    "minipass": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+      "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.1",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "dev": true
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -9339,6 +9381,17 @@
             "through": "2"
           }
         },
+        "tar": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.0.tgz",
+          "integrity": "sha1-NmNtduiuErS8EalArGBrXKil/h8=",
+          "dev": true,
+          "requires": {
+            "block-stream": "*",
+            "fstream": "^1.0.0",
+            "inherits": "2"
+          }
+        },
         "tunnel-agent": {
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
@@ -9410,14 +9463,26 @@
       "dev": true
     },
     "tar": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.0.tgz",
-      "integrity": "sha1-NmNtduiuErS8EalArGBrXKil/h8=",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+      "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
       "dev": true,
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.0",
-        "inherits": "2"
+        "chownr": "^1.0.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.2.4",
+        "minizlib": "^1.1.0",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.1",
+        "yallist": "^3.0.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "dev": true
+        }
       }
     },
     "tar.gz": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "rimraf": "2.6.2",
     "style-loader": "0.19.0",
     "surge": "0.19.0",
+    "tar": "4.4.1",
     "webpack": "3.6.0",
     "webpack-dev-middleware": "1.12.0",
     "webpack-hot-middleware": "2.19.1",


### PR DESCRIPTION
Github notes a security vulnerability in tar v1.0.0, so manually install newer version.